### PR TITLE
Fix/buddy user view minors

### DIFF
--- a/app/actions/registration.js
+++ b/app/actions/registration.js
@@ -151,7 +151,7 @@ const getLookingForTypes = () => (dispatch) => {
     .catch(error => dispatch({ type: GET_LOOKING_FOR_TYPES_FAILURE, error: true, payload: error }));
 }
 
-const putBuddyProfile = () => {
+const putBuddyProfile = (onPutError) => {
   return (dispatch, getStore) => {
     dispatch({ type: CREATE_USER_REQUEST });
     const uuid = DeviceInfo.getUniqueID();
@@ -164,10 +164,13 @@ const putBuddyProfile = () => {
     const class_year = getStore().registration.get('class_year');
     return api.putBuddyProfile({ uuid, bio_text, bio_looking_for_type_id, pushToken, class_year })
       .then(response => {
-        dispatch({type: CREATE_USER_SUCCESS});
+        dispatch({ type: CREATE_USER_SUCCESS });
         dispatch({ type: CLOSE_BUDDY_REGISTRATION_VIEW });
       })
-      .catch(error => dispatch({type: CREATE_USER_FAILURE, error: error}));
+      .catch(error => {
+        dispatch({ type: CREATE_USER_FAILURE, error: error });
+        onPutError();
+      });
   };
 };
 

--- a/app/components/whappubuddy/BuddyRegistrationView.js
+++ b/app/components/whappubuddy/BuddyRegistrationView.js
@@ -4,6 +4,7 @@
 
 import React, { Component } from 'react';
 import {
+  Alert,
   Dimensions,
   Modal,
   Picker,
@@ -49,7 +50,7 @@ class BuddyRegistrationView extends Component {
 
   @autobind
   saveProfile() {
-    this.props.putBuddyProfile();
+    this.props.putBuddyProfile(this.onSaveError);
   }
 
   @autobind
@@ -70,6 +71,20 @@ class BuddyRegistrationView extends Component {
   @autobind
   onRequestClose() {
     this.props.closeBuddyRegistrationView();
+  }
+
+  @autobind
+  onSaveError() {
+    Alert.alert(
+      'Incomplete information',
+      'Please fill in all the fields!',
+      [
+        { text: 'Close profile editor',
+          onPress: () => this.onRequestClose(), style: 'cancel' },
+        { text: 'Okay, let me fix that',
+          onPress: () => { return }, style: 'default' }
+      ]
+    );
   }
 
   @autobind
@@ -94,7 +109,7 @@ class BuddyRegistrationView extends Component {
           <TextInput
             ref={view => this.bioTextInputRef = view}
             autoCorrect={false}
-            autoCapitalize={'words'}
+            autoCapitalize={'sentences'}
             clearButtonMode={'while-editing'}
             maxLength={250}
             multiline={true}
@@ -305,10 +320,10 @@ const select = store => {
     buddyBio: store.registration.get('bio_text'),
     buddyLookingFor: store.registration.get('bio_looking_for_type_id'),
     buddyClassYear: store.registration.get('class_year'),
+    isBuddyRegistrationViewOpen: store.registration.get('isBuddyRegistrationViewOpen'),
     lookingForTypes: store.registration.get('lookingForTypes'),
     userId: store.registration.get('userId'),
-    userName: store.registration.get('name'),
-    isBuddyRegistrationViewOpen: store.registration.get('isBuddyRegistrationViewOpen')
+    userName: store.registration.get('name')
   };
 };
 

--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -464,7 +464,6 @@ const mapStateToProps = state => ({
   userId: getUserId(state),
   userName: getUserName(state),
   userTeam: getUserTeam(state),
-  image_url: getUserImageUrl(state),
   tab: getCurrentTab(state),
 });
 

--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -17,6 +17,7 @@ import {
 } from 'react-native';
 import { connect } from 'react-redux';
 import autobind from 'autobind-decorator';
+import { parseInt } from 'lodash';
 
 import {
   fetchUserProfile,
@@ -70,14 +71,6 @@ class BuddyUserView extends Component {
   @autobind
   showWhappuLog() {
     let { user } = this.props.route;
-    const { userName } = this.props;
-
-    //console.log(user.id);
-
-    // Show Current user if not user selected
-    if (!user) {
-      user = { name: userName };
-    }
 
     return () => {
       this.props.navigator.push({
@@ -105,7 +98,13 @@ class BuddyUserView extends Component {
   onMyPopupEvent = (eventName, index) => {
 
     if (eventName !== 'itemSelected') return
-    if (index === 0) this.onDeleteProfile()
+    if (index === 0) this.onEditProfile()
+    if (index === 1) this.onDeleteProfile()
+  }
+
+  @autobind
+  onEditProfile() {
+    this.props.openBuddyRegistrationView();
   }
 
   onDeleteProfile = () => {
@@ -147,16 +146,35 @@ class BuddyUserView extends Component {
     this.props.submitOpinion(Subpackage);
   }
 
-  @autobind
-  openBuddyRegistration() {
-    this.props.openBuddyRegistrationView();
-  }
-
+  // Adds ordinal endings to the class year
   @autobind
   renderClassYear() {
-    if (this.props.buddyClassYear) {
-      // TODO: Add the class year ordering to the end of the number: st, nd, rd, th
-      return this.props.buddyClassYear;
+    const { buddyClassYear } = this.props;
+
+    if (buddyClassYear) {
+      const lastChar =buddyClassYear.slice(-1);
+      let ordinal = 'th';
+
+      switch (parseInt(lastChar)) {
+        case 1:
+          ordinal = 'st';
+          break;
+        case 2:
+          ordinal = 'nd';
+          break;
+        case 3:
+          ordinal = 'rd';
+          break;
+        default:
+      }
+
+      // 11, 12 and 13 are always 'th'
+      const parsed = parseInt(buddyClassYear);
+      if (parsed == 11 || parsed == 12 || parsed == 13) {
+        ordinal = 'th';
+      }
+      
+      return buddyClassYear + ordinal;
     } else {
       return '';
     }
@@ -208,7 +226,7 @@ class BuddyUserView extends Component {
 
             {user.name === userName && !isIOS &&
               <View style={styles.menu}>
-                <PopupMenu actions={['Delete my profile']} onPress={this.onMyPopupEvent} />
+                <PopupMenu actions={['Edit my profile', 'Delete my profile']} onPress={this.onMyPopupEvent} />
               </View>
             }
 
@@ -242,6 +260,9 @@ class BuddyUserView extends Component {
           </Text>
         </View>
         <View style={styles.thumbs}>
+        
+        { /* Only show the opinion buttons as well as the Whappu Log connection button if this is not
+             the user's own profile */}
         {user.id &&
           <View style={{flex: 1, flexDirection: 'row'}}>
           <TouchableHighlight onPress={this.onLikePress}>
@@ -253,6 +274,7 @@ class BuddyUserView extends Component {
           </View>
         }
         </View>
+        {user.id &&
         <View style={styles.logButtonView}>
           <Button
             onPress={this.showWhappuLog()}
@@ -262,6 +284,7 @@ class BuddyUserView extends Component {
             Check out my Whappu Log
           </Button>
         </View>
+        }
 
       </ParallaxView>
       </View>

--- a/app/concepts/buddyUser.js
+++ b/app/concepts/buddyUser.js
@@ -4,6 +4,11 @@ import { parseInt } from 'lodash';
 
 import api from '../services/api';
 import {createRequestActionTypes} from '../actions';
+import {
+  UPDATE_BUDDY_BIO,
+  UPDATE_BUDDY_CLASS_YEAR,
+  UPDATE_BUDDY_LOOKING_FOR
+} from '../actions/registration';
 
 // # Selectors
 export const getBuddyBio = state => state.buddyUser.getIn(['buddyProfile', 'bio_text'], '') || '';
@@ -28,6 +33,9 @@ export const fetchBuddyProfile = (userId) => (dispatch) => {
         payload: buddyProfile
       });
       dispatch({ type: GET_BUDDY_PROFILE_SUCCESS });
+      dispatch({ type: UPDATE_BUDDY_BIO, payload: buddyProfile.bio_text });
+      dispatch({ type: UPDATE_BUDDY_LOOKING_FOR, payload: buddyProfile.bio_looking_for_type_id });
+      dispatch({ type: UPDATE_BUDDY_CLASS_YEAR, payload: buddyProfile.class_year });
     })
     .catch(error => dispatch({ type: GET_BUDDY_PROFILE_FAILURE, error: true, payload: error }));
 }

--- a/app/concepts/user.js
+++ b/app/concepts/user.js
@@ -14,6 +14,9 @@ export const getTotalSimas = state => state.user.getIn(['profile', 'numSimas'], 
 export const getSelectedUser = state => state.user.get('selectedUser', Map()) || Map();
 export const isLoadingUserImages = state => state.user.get('isLoading', false) || false;
 export const getUserImageUrl = state => state.user.getIn(['profile', 'image_url'], '') || '';
+// TODO: Fix hasRegisteredOnWhappuBuddy once the backend fix has been applied
+export const hasRegisteredOnWhappuBuddy = state => true;
+// export const hasRegisteredOnWhappuBuddy = state => state.user.get(['profile', 'heila'], false) || false;
 
 export const getTotalVotesForUser = createSelector(
   getUserImages, (posts) => {


### PR DESCRIPTION
- Added error alert if the user has not filled in all fields in BuddyRegistrationView.
- Added conditions for showing the "Find me on WhappuBuddy" button in UserView: it must not be the user's own profile and the target user must be registered on WhappuBuddy.
- Added conditions for showing the "Check out my Whappu Log" button in BuddyUserView: it must not be the user's own profile.
- Added an "Edit my profile" option to BuddyUserView's popup menu, leading to BuddyRegistrationView.
- Added ordinal endings to the class year text in BuddyUserView.
- Fixed BuddyRegistrationView not showing initial field values (if set in the backend).
- Fixed auto-correction in the bio field of BuddyRegistrationView.
- Removed some debug messages and added some comments for clarity.
- Reordered some code bits for clarity and elegance.

Known issues:
- The opinion buttons in BuddyUserView are hidden if the user has actual profile data displayed.
- BuddyUserView information is not correct after entering the view through the main navigation bar and having viewed another user's WhappuBuddy profile previously.
- BuddyUserView information is not updated after making changes in BuddyRegistrationView, saving them and having BuddyRegistrationView close.
- Whitespace is an allowed class year value which leads to weird ordinals, like "  th".
- If you access your own UserView through the feed, the "Find me on WhappuBuddy" button is not invisible. If you access your own BuddyUserView through that button, the "Check out my Whappu Log" button is not invisible there either. This is probably because the user object gets passed from the feed, unlike through the main navigation bar. So user.id is actually found when accessing the profiles through the feed.