### PR TITLE
Fix BuddyUserView data updating

### DIFF
--- a/app/actions/registration.js
+++ b/app/actions/registration.js
@@ -32,6 +32,8 @@ const DISMISS_INTRODUCTION = 'DISMISS_INTRODUCTION';
 const UPDATE_PROFILE_PIC = 'UPDATE_PROFILE_PIC';
 const OPEN_BUDDY_REGISTRATION_VIEW = 'OPEN_BUDDY_REGISTRATION_VIEW';
 const CLOSE_BUDDY_REGISTRATION_VIEW = 'CLOSE_BUDDY_REGISTRATION_VIEW';
+const ACKNOWLEDGE_DATA_UPDATE = 'ACKNOWLEDGE_DATA_UPDATE';
+const SET_DATA_UPDATED = 'SET_DATA_UPDATED';
 const UPDATE_BUDDY_BIO = 'UPDATE_BUDDY_BIO';
 const UPDATE_BUDDY_CLASS_YEAR = 'UPDATE_BUDDY_CLASS_YEAR';
 const UPDATE_BUDDY_LOOKING_FOR = 'UPDATE_BUDDY_LOOKING_FOR';
@@ -59,6 +61,7 @@ const putUser = () => {
       .then(response => {
         dispatch({ type: CREATE_USER_SUCCESS });
         dispatch({ type: CLOSE_REGISTRATION_VIEW });
+        dispatch({ type: SET_DATA_UPDATED });
       })
       .catch(error => dispatch({ type: CREATE_USER_FAILURE, error: error }));
   };
@@ -71,9 +74,9 @@ const putProfilePic = () => {
     const imageData = getStore().registration.get('profilePic');
     return api.putProfilePic({ uuid, imageData })
       .then(response => {
-        dispatch({type: CREATE_USER_SUCCESS})
+        dispatch({ type: CREATE_USER_SUCCESS });
       })
-      .catch(error => dispatch({type: CREATE_USER_FAILURE, error: error}));
+      .catch(error => dispatch({ type: CREATE_USER_FAILURE, error: error }));
   };
 };
 
@@ -142,6 +145,10 @@ const closeBuddyRegistrationView = () => {
   return { type: CLOSE_BUDDY_REGISTRATION_VIEW };
 };
 
+const acknowledgeDataUpdate = () => {
+  return { type: ACKNOWLEDGE_DATA_UPDATE };
+};
+
 const getLookingForTypes = () => (dispatch) => {
   dispatch({ type: GET_LOOKING_FOR_TYPES_REQUEST });
   return api.getLookingForTypes()
@@ -166,6 +173,7 @@ const putBuddyProfile = (onPutError) => {
       .then(response => {
         dispatch({ type: CREATE_USER_SUCCESS });
         dispatch({ type: CLOSE_BUDDY_REGISTRATION_VIEW });
+        dispatch({ type: SET_DATA_UPDATED });
       })
       .catch(error => {
         dispatch({ type: CREATE_USER_FAILURE, error: error });
@@ -208,6 +216,8 @@ export {
   DISMISS_INTRODUCTION,
   OPEN_BUDDY_REGISTRATION_VIEW,
   CLOSE_BUDDY_REGISTRATION_VIEW,
+  ACKNOWLEDGE_DATA_UPDATE,
+  SET_DATA_UPDATED,
   GET_LOOKING_FOR_TYPES_REQUEST,
   GET_LOOKING_FOR_TYPES_SUCCESS,
   GET_LOOKING_FOR_TYPES_FAILURE,
@@ -228,6 +238,7 @@ export {
   dismissIntroduction,
   openBuddyRegistrationView,
   closeBuddyRegistrationView,
+  acknowledgeDataUpdate,
   getLookingForTypes,
   putBuddyProfile,
   updateBuddyBio,

--- a/app/components/user/UserView.js
+++ b/app/components/user/UserView.js
@@ -17,7 +17,7 @@ import {
   isLoadingUserImages,
   hasRegisteredOnWhappuBuddy
 } from '../../concepts/user';
-import { getUserName, getUserId } from '../../reducers/registration';
+import { getUserName, getUserId, isDataUpdated } from '../../reducers/registration';
 import { getCurrentTab } from '../../reducers/navigation';
 import { openLightBox } from '../../actions/feed';
 
@@ -36,7 +36,7 @@ import AppInfo from './AppInfo';
 import LegalStuff from './LegalStuff';
 import PopupMenu from './PopupMenu';
 
-import { openRegistrationView } from '../../actions/registration';
+import { openRegistrationView, acknowledgeDataUpdate } from '../../actions/registration';
 import { getCurrentCityName } from '../../concepts/city';
 import WebViewer from '../webview/WebViewer';
 import BuddyUserView from '../whappubuddy/BuddyUserView';
@@ -73,6 +73,15 @@ class UserView extends Component {
     // Fetch images and data on Settings tab if this is the user's own profile
     if (tab !== this.props.tab && tab === 'SETTINGS') {
       this.props.fetchUserImages(userId);
+      this.props.fetchUserProfile(userId);
+    }
+  }
+
+  componentDidUpdate() {
+    // Ensure that the user data is updated right after editing the profile
+    if (this.props.isDataUpdated) {
+      const { userId } = this.props;
+      this.props.acknowledgeDataUpdate();
       this.props.fetchUserProfile(userId);
     }
   }
@@ -192,6 +201,7 @@ class UserView extends Component {
                 }
               </View>
             }
+            
             {/* Load user's profile picture or avatar with initials */}
             {!isLoading ? (
               <View>
@@ -474,7 +484,13 @@ const styles = StyleSheet.create({
 });
 
 
-const mapDispatchToProps = { openLightBox, fetchUserImages, openRegistrationView, fetchUserProfile };
+const mapDispatchToProps = {
+  acknowledgeDataUpdate,
+  fetchUserImages,
+  fetchUserProfile,
+  openLightBox,
+  openRegistrationView
+};
 
 const mapStateToProps = state => ({
   images: getUserImages(state),
@@ -487,7 +503,8 @@ const mapStateToProps = state => ({
   cityName: getCurrentCityName(state),
   tab: getCurrentTab(state),
   image_url: getUserImageUrl(state),
-  isOnWhappuBuddy: hasRegisteredOnWhappuBuddy(state)
+  isOnWhappuBuddy: hasRegisteredOnWhappuBuddy(state),
+  isDataUpdated: isDataUpdated(state)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserView);

--- a/app/components/whappubuddy/BuddyRegistrationView.js
+++ b/app/components/whappubuddy/BuddyRegistrationView.js
@@ -38,6 +38,7 @@ import {
 import theme from '../../style/theme';
 import Header from '../common/Header';
 import Button from '../../components/common/Button';
+import Toolbar from '../registration/RegistrationToolbar';
 
 const { height, width } = Dimensions.get('window');
 const IOS = Platform.OS === 'ios';
@@ -60,7 +61,8 @@ class BuddyRegistrationView extends Component {
 
   @autobind
   onChangeClassYear(buddyClassYear) {
-    this.props.updateBuddyClassYear(buddyClassYear);
+    const trimmedYear = buddyClassYear.trim();
+    this.props.updateBuddyClassYear(trimmedYear);
   }
 
   @autobind
@@ -101,7 +103,7 @@ class BuddyRegistrationView extends Component {
 
   _renderBioSelect() {
     return (
-      <View style={[styles.inputGroup, {marginBottom:4}]}>
+      <View style={[styles.inputGroup, {marginTop: 10}]}>
         <View style={styles.inputLabel}>
           <Text style={styles.inputLabelText}>{`Write a short bio (max. 250 characters)`}</Text>
         </View>
@@ -133,7 +135,7 @@ class BuddyRegistrationView extends Component {
 
   _renderClassYearSelect() {
     return (
-      <View style={[styles.inputGroup, {marginBottom:4}]}>
+      <View style={[styles.inputGroup, {marginTop: 10}]}>
         <View style={styles.inputLabel}>
           <Text style={styles.inputLabelText}>{`What's your current class year?`}</Text>
         </View>
@@ -163,7 +165,7 @@ class BuddyRegistrationView extends Component {
 
   _renderLookingForSelect() {
     return (
-      <View style={[styles.inputGroup, {marginBottom:4}]}>
+      <View style={[styles.inputGroup, {marginTop: 10}]}>
         <View style={styles.inputLabel}>
           <Text style={styles.inputLabelText}>{`What kind of Wappu company are you looking for?`}</Text>
         </View>
@@ -187,24 +189,30 @@ class BuddyRegistrationView extends Component {
         animationType={'slide'}
         onRequestClose={this.onRequestClose}
       >
+        <Toolbar icon={'done'}
+          iconClick={this.onRequestClose}
+          title='Fill your WhappuBuddy profile' />
+
         <ScrollView
           ref={view => this.containerScrollViewRef = view}
           showsVerticalScrollIndicator={true}
-          style={{flex:1}}>
+          style={styles.container}>
           <View style={[styles.innerContainer]}>
             {this._renderBioSelect()}
             {this._renderLookingForSelect()}
             {this._renderClassYearSelect()}
           </View>
+        </ScrollView>
           
+        <View style={styles.bottomButtonContainer}>
           <Button
             onPress={this.saveProfile}
-            style={styles.button}
+            style={styles.saveButton}
             isDisabled={false}
           >
-            Save your profile
-          </Button> 
-        </ScrollView>
+            Save
+          </Button>
+        </View>
       </Modal>
     );
   }
@@ -213,17 +221,6 @@ class BuddyRegistrationView extends Component {
 
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.white,
-  },
-  header: {
-    flex:1,
-    elevation: 3,
-    paddingTop: 30,
-    alignItems: 'center',
-    justifyContent: 'flex-end'
-  },
   backLink: {
     position: 'absolute',
     left: 7,
@@ -241,6 +238,20 @@ const styles = StyleSheet.create({
   backLinkIcon: {
     color: theme.white
   },
+  bottomButtonContainer:{
+    flex:1,
+    flexDirection:'row',
+    margin:0,
+    marginBottom:0,
+    marginLeft:0,
+    marginRight:0,
+    height:50,
+    alignItems:'stretch',
+    position:'absolute',
+    bottom:0,
+    left:0,
+    right:0,
+  },
   button: {
     height: 35,
     borderRadius: 2,
@@ -248,6 +259,18 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
     alignItems: 'center',
     justifyContent: 'center'
+  },
+  container: {
+    flex: 1,
+    backgroundColor: '#eee',
+    paddingBottom: 50,
+  },
+  header: {
+    flex:1,
+    elevation: 3,
+    paddingTop: 30,
+    alignItems: 'center',
+    justifyContent: 'flex-end'
   },
   innerContainer: {
     flex:1,
@@ -301,6 +324,11 @@ const styles = StyleSheet.create({
   item: {
     flex: 1
   },
+  saveButton: {
+    borderRadius:0,
+    flex:1,
+    marginLeft:0,
+  }
 });
 
 

--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -225,7 +225,7 @@ class BuddyUserView extends Component {
       {false && <Header backgroundColor={theme.secondary} title={user.name} navigator={navigator} />}
       <ParallaxView
         backgroundSource={headerImage}
-        windowHeight={430}
+        windowHeight={height/1.8}
         style={{ backgroundColor:theme.white }}
         header={(
           <View style={styles.header}>

--- a/app/reducers/registration.js
+++ b/app/reducers/registration.js
@@ -18,9 +18,11 @@ import {
   RESET,
   OPEN_BUDDY_REGISTRATION_VIEW,
   CLOSE_BUDDY_REGISTRATION_VIEW,
+  ACKNOWLEDGE_DATA_UPDATE,
   GET_LOOKING_FOR_TYPES_FAILURE,
   GET_LOOKING_FOR_TYPES_REQUEST,
   GET_LOOKING_FOR_TYPES_SUCCESS,
+  SET_DATA_UPDATED,
   UPDATE_BUDDY_BIO,
   UPDATE_BUDDY_CLASS_YEAR,
   UPDATE_BUDDY_LOOKING_FOR,
@@ -45,6 +47,7 @@ const initialState = fromJS({
   bio_text: '',
   bio_looking_for_type_id: 1,
   class_year: '',
+  isDataUpdated: false,
   lookingForTypes: [],
   pushToken: ''
 });
@@ -109,11 +112,15 @@ export default function registration(state = initialState, action) {
       return state.set('isBuddyRegistrationViewOpen', true);
     case CLOSE_BUDDY_REGISTRATION_VIEW:
       return state.set('isBuddyRegistrationViewOpen', false);
+    case ACKNOWLEDGE_DATA_UPDATE:
+      return state.set('isDataUpdated', false);
     case GET_LOOKING_FOR_TYPES_SUCCESS:
       return state.merge({
         'lookingForTypes': List(action.payload),
         'isLoading': false
       });
+    case SET_DATA_UPDATED:
+      return state.set('isDataUpdated', true);
     case UPDATE_BUDDY_BIO:
       return state.set('bio_text', action.payload);
     case UPDATE_BUDDY_CLASS_YEAR:
@@ -134,3 +141,4 @@ export const getUserTeamId = state => state.registration.get('selectedTeam', 0);
 export const getUserTeam = createSelector(getUserTeamId, getTeams,
   (teamId, teams) => teams.find(item => item.get('id') === teamId))
 export const getLookingForTypes = state => state.registration.get('lookingForTypes');
+export const isDataUpdated = state => state.registration.get('isDataUpdated');


### PR DESCRIPTION
- Fixed the BuddyUserView data not getting updated right after changing the profile in BuddyRegistrationView and closing the modal view.
- Fixed the team and profile picture in UserView not getting updated right after changing the profile in RegistrationView and closing the modal view.
- Fixed the BuddyUserView data not updating when entering the view through the main navigation bar and having viewed another user's WhappuBuddy profile previously.
- Fixed the class year attribute previously allowing whitespace in its value.
- Changed the UI style of BuddyRegistrationView to correspond to RegistrationView's style.
- Made BuddyUserView's ParallaxView height dynamic according to display height and also somewhat more reasonable-sized.
- Refactored class year rendering in BuddyUserView for clarity.

Known issues :
- The opinion buttons in BuddyUserView are hidden if the user has actual profile data displayed.
- If you access your own UserView through the feed, the "Find me on WhappuBuddy" button is not invisible. If you access your own BuddyUserView through that button, the "Check out my Whappu Log" button is not invisible there either. This is probably because the user object gets passed from the feed, unlike through the main navigation bar. So user.id is actually found when accessing the profiles through the feed.
- The UserAvatar profile picture in RegistrationView is not updated after changing it, saving the changes and accessing RegistrationView again.