### PR TITLE
Hotfixes

### DIFF
--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -86,6 +86,7 @@ class BuddyUserView extends Component {
     if (tab !== this.props.tab && tab === 'BUDDY') {
       this.props.fetchUserImages(userId);
       this.props.fetchUserProfile(userId);
+      this.props.fetchBuddyProfile(userId);
     }
   }
 

--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -323,6 +323,9 @@ class BuddyUserView extends Component {
               </Text>
               <Text style={styles.headerSubTitle}>
               {this.props.buddies.size > 0 &&
+                this.state.buddyToShow.team || userTeam || "The Guild"
+              }
+              {this.props.buddies.size > 0 &&
                 this.renderClassYear(this.state.buddyToShow.class_year) || this.renderClassYear(buddyClassYear) || "69 BC"
               }
               </Text>


### PR DESCRIPTION
- Team was accidentally dropped from BuddyUserView in some merge. Added it back.
- Refixed BuddyUserView data not updating. Data from previous BuddyUserView instances would again be displayed when accessing the component through the navigation bar because the old fix was lost in a merge.

Known issues:
- The opinion buttons in BuddyUserView are hidden if the user has actual profile data displayed.
- The UserAvatar profile picture in RegistrationView is not updated after changing it, saving the changes and accessing RegistrationView again.
- Browsing Buddies does not work in the Buddy view (from main navigation bar) but works when accessed through the feed.