### PR TITLE
Added tab navigation for WhappuBuddy.

### DIFF
--- a/app/actions/registration.js
+++ b/app/actions/registration.js
@@ -172,6 +172,10 @@ const acknowledgeDataUpdate = () => {
   return { type: ACKNOWLEDGE_DATA_UPDATE };
 };
 
+const broadcastDataUpdate = () => {
+  return { type: SET_DATA_UPDATED };
+};
+
 const closeBuddyIntroView = () => {
   return { type: CLOSE_BUDDY_INTRO_VIEW };
 };
@@ -309,6 +313,7 @@ export {
   reset,
   dismissIntroduction,
   acknowledgeDataUpdate,
+  broadcastDataUpdate,
   closeBuddyIntroView,
   closeBuddyRegistrationView,
   getBuddyUser,

--- a/app/components/user/UserView.js
+++ b/app/components/user/UserView.js
@@ -112,7 +112,8 @@ class UserView extends Component {
       this.props.navigator.push({
         component: BuddyUserView,
         name: `${user.name}`,
-        user
+        user,
+        fromWhappuLog: true
       });
     };
   }
@@ -338,8 +339,10 @@ closePopModal = () => {
 
             {/* Ugly but this hack is needed to render the WhappuBuddy connection button in a correct manner.
                 Also only renders the button if the user is viewing someone else's UserView than their own
-                and that someone else has registered on WhappuBuddy. */}
-            {(!isLoading && !this.isCurrentUser() && this.props.isOnWhappuBuddy) ? (
+                and that someone else has registered on WhappuBuddy. Does not render if the user is already
+                coming here from WhappuBuddy. */}
+            {(!isLoading && !this.isCurrentUser() && !this.props.route.fromWhappuBuddy &&
+              this.props.isOnWhappuBuddy) ? (
               <View style={styles.headerKpis}>
                 <View style={styles.buddyButtonView}>
                   <Button

--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -109,10 +109,19 @@ class BuddyUserView extends Component {
 
   componentDidUpdate() {
     // Ensure that the user data is updated right after editing the WhappuBuddy profile
-    if (this.props.isDataUpdated) {
-      const { userId } = this.props;
+    // as well as after switching WhappuBuddy tabs
+    const { userId } = this.props;
+
+    if (this.props.isDataUpdated && this.props.isOwnBuddyProfileShown) {
       this.props.acknowledgeDataUpdate();
       this.props.fetchBuddyProfile(userId);
+
+    // Ensure that Discover mode is re-entered after changing tabs
+    } else if (this.props.isDataUpdated && !this.props.isOwnBuddyProfileShown) {
+      this.props.acknowledgeDataUpdate();
+      this.props.fetchUserBuddies(userId).then(() => {
+        this.props.updateCurrentBuddy(this.props.buddies.get(0));
+      });
     }
   }
 
@@ -121,6 +130,12 @@ class BuddyUserView extends Component {
     let user = this.props.currentBuddy;
     const { userId } = this.props;
 
+    // For My Profile mode
+    if (this.props.isOwnBuddyProfileShown) {
+      return true;
+    }
+
+    // For Discover mode and accessing through Whappu Log
     if (user) {
       if (user.id == userId) {
         return true;
@@ -148,7 +163,8 @@ class BuddyUserView extends Component {
       this.props.navigator.push({
         component: UserView,
         name: user.name,
-        user
+        user,
+        fromWhappuBuddy: true
       });
     };
   }
@@ -301,7 +317,7 @@ class BuddyUserView extends Component {
       >
         <ParallaxView
           backgroundSource={headerImage}
-          windowHeight={height / 1.8}
+          windowHeight={height / 2.3}
           style={{ backgroundColor:theme.white }}
           header={(
 
@@ -392,8 +408,9 @@ class BuddyUserView extends Component {
             )}
         >
         
-          { /* Only show the Whappu Log connection button if this is not the user's own profile */}
-          {!this.isCurrentUser() &&
+          { /* Only show the Whappu Log connection button if this is not the user's own profile
+               and if the user has not arrived here from a Whappu Log */}
+          {!this.isCurrentUser() && !this.props.route.fromWhappuLog &&
           <View style={styles.logButtonView}>
             <Button
               onPress={this.showWhappuLog()}

--- a/app/containers/BuddyView.js
+++ b/app/containers/BuddyView.js
@@ -8,10 +8,18 @@ import {
 } from 'react-native';
 import { connect } from 'react-redux';
 import autobind from 'autobind-decorator';
+import ScrollableTabView from 'react-native-scrollable-tab-view';
 
+import TabBarItems from '../components/tabs/Tabs';
 import BuddyUserView from '../components/whappubuddy/BuddyUserView';
+import {
+  broadcastDataUpdate,
+  showOtherBuddyProfile,
+  showOwnBuddyProfile
+} from '../actions/registration';
 
 const theme = require('../style/theme');
+const isIOS = Platform.OS === 'ios';
 
 const styles = StyleSheet.create({
   navigator: {
@@ -36,25 +44,99 @@ class BuddyView extends Component {
     }
   }
 
+  @autobind
+  onChangeTab(selectedTab) {
+    const tabIndex = selectedTab.i;
+
+    switch (tabIndex) {
+    case 0:
+      // TODO: Insert MatchesView stuff if needed
+      break;
+    case 1:
+      this.props.showOtherBuddyProfile();
+      this.props.broadcastDataUpdate();
+      break;
+    case 2:
+      this.props.showOwnBuddyProfile();
+      this.props.broadcastDataUpdate();
+      break;
+    default:
+    }
+  }
+
   render() {
     return (
-      <Navigator
-        style={styles.navigator}
-        initialRoute={{
-          component: BuddyUserView,
-          name: 'WhappuBuddy'
-        }}
-        renderScene={this.renderScene}
-        configureScene={() => ({
-          ...Navigator.SceneConfigs.FloatFromRight
-        })}
-      />
+      <ScrollableTabView
+        onChangeTab={this.onChangeTab}
+        initialPage={1}
+        tabBarActiveTextColor={theme.secondary}
+        tabBarUnderlineColor={theme.secondary}
+        tabBarBackgroundColor={theme.white}
+        tabBarInactiveTextColor={'rgba(0,0,0,0.6)'}
+        locked={isIOS}
+        prerenderingSiblingsNumber={0}
+        renderTabBar={() => <TabBarItems />}    
+      >
+        <Navigator
+          key={0}
+          style={styles.navigator}
+          initialRoute={{
+            component: BuddyUserView,
+            name: 'My Profile'
+          }}
+          renderScene={this.renderScene}
+          configureScene={() => ({
+            ...Navigator.SceneConfigs.FloatFromRight
+          })}
+          tabLabel="My Profile"
+          barColor={theme.accent}
+          ref="myProfile"
+        />
+        <Navigator
+          key={1}
+          style={styles.navigator}
+          initialRoute={{
+            component: BuddyUserView,
+            name: 'Discover'
+          }}
+          renderScene={this.renderScene}
+          configureScene={() => ({
+            ...Navigator.SceneConfigs.FloatFromRight
+          })}
+          tabLabel="Discover"
+          barColor={theme.positive}
+          ref="discover"
+        />
+        { /* TODO: Change this to route to MatchesView */ }
+        <Navigator
+          key={2}
+          style={styles.navigator}
+          initialRoute={{
+            component: BuddyUserView,
+            name: 'Matches'
+          }}
+          renderScene={this.renderScene}
+          configureScene={() => ({
+            ...Navigator.SceneConfigs.FloatFromRight
+          })}
+          tabLabel="Matches"
+          barColor={theme.accent}
+          ref="matches"
+        />
+      </ScrollableTabView>
+
     );
   }
 }
+
+const mapDispatchToProps = {
+  broadcastDataUpdate,
+  showOtherBuddyProfile,
+  showOwnBuddyProfile
+};
 
 const select = store => {
   return {};
 };
 
-export default connect(select)(BuddyView);
+export default connect(select, mapDispatchToProps)(BuddyView);

--- a/app/containers/Navigation.android.js
+++ b/app/containers/Navigation.android.js
@@ -20,7 +20,6 @@ import CompetitionView from './CompetitionNavigator';
 import BuddyView from './BuddyView';
 import FeedView from './FeedView';
 import ProfileView from './ProfileView';
-import UserView from '../components/user/UserView';
 import AndroidTabs  from 'react-native-scrollable-tab-view';
 import Header from '../components/common/MainHeader';
 import CitySelector from '../components/header/CitySelector';

--- a/app/containers/ProfileView.js
+++ b/app/containers/ProfileView.js
@@ -43,7 +43,7 @@ class ProfileView extends Component {
         style={styles.navigator}
         initialRoute={{
           component: UserView,
-          name: 'Settings'
+          name: 'Profile'
         }}
         renderScene={this.renderScene}
         configureScene={() => ({


### PR DESCRIPTION
- Added tab navigation for WhappuBuddy. Still requires the MatchesView to be integrated.
- Resized the BuddyUserView ParallaxView (the header image) to be a bit smaller for the view to better fit below the header and tab bars.
- "Check out my Whappu Log" is no longer rendered on BuddyUserView if the user arrived there from the corresponding Whappu Log.
- "Find me on WhappuBuddy" is no longer rendered on UserView if the user arrived there from the corresponding WhappuBuddy profile.
- Changed the name of the ProfileView/UserView component in the main navigation bar from the previous "Settings" to "Profile".
- Removed an unused import from Navigation.android.js.

Known issues:
- The UserAvatar profile picture in RegistrationView is not updated after changing it, saving the changes and accessing RegistrationView again.
- If the user hasn't registered on WhappuBuddy, fetchUserBuddies returns an empty list and potential buddies cannot be browsed. This might be a backend problem.
- The opinion and skip buttons in BuddyUserView don't have shadows on Android because Image cannot have the style property 'elevation'.
- Part of the ParallaxView header (containing the user's name, guild and class year) is not rendered at times. This is currently somehow fixed (in a dirty and ugly way) by having added invisible View and Text elements above it.