### PR TITLE
Push Notification and BuddyUserView fixes.

### DIFF
--- a/app/actions/registration.js
+++ b/app/actions/registration.js
@@ -1,5 +1,3 @@
-// TODO: Remove pushToken hardcoding after the back-end and token generation have been fixed
-
 import DeviceInfo from 'react-native-device-info';
 import api from '../services/api';
 import namegen from '../services/namegen';
@@ -27,11 +25,11 @@ const {
   GET_LOOKING_FOR_TYPES_SUCCESS,
   GET_LOOKING_FOR_TYPES_FAILURE
 } = createRequestActionTypes('GET_LOOKING_FOR_TYPES');
-
-const {DELETE_BUDDY_PROFILE_REQUEST,
-      DELETE_BUDDY_PROFILE_SUCCESS,
-      DELETE_BUDDY_PROFILE_FAILURE}
- = createRequestActionTypes('DELETE_BUDDY_PROFILE');
+const {
+  DELETE_BUDDY_PROFILE_REQUEST,
+  DELETE_BUDDY_PROFILE_SUCCESS,
+  DELETE_BUDDY_PROFILE_FAILURE}
+= createRequestActionTypes('DELETE_BUDDY_PROFILE');
 
 const OPEN_REGISTRATION_VIEW = 'OPEN_REGISTRATION_VIEW';
 const CLOSE_REGISTRATION_VIEW = 'CLOSE_REGISTRATION_VIEW';
@@ -53,6 +51,7 @@ const UPDATE_BUDDY_BIO = 'UPDATE_BUDDY_BIO';
 const UPDATE_BUDDY_CLASS_YEAR = 'UPDATE_BUDDY_CLASS_YEAR';
 const UPDATE_BUDDY_LOOKING_FOR = 'UPDATE_BUDDY_LOOKING_FOR';
 const UPDATE_BUDDY_PUSH_TOKEN = 'UPDATE_BUDDY_PUSH_TOKEN';
+const UPDATE_BUDDY_REGISTRATION = 'UPDATE_BUDDY_REGISTRATION';
 
 const openRegistrationView = () => {
   return { type: OPEN_REGISTRATION_VIEW };
@@ -147,21 +146,6 @@ const getUser = () => {
   };
 };
 
-const deleteBuddyProfile = () => {
-  return dispatch => {
-    dispatch({ type: DELETE_BUDDY_PROFILE_REQUEST });
-    const uuid = DeviceInfo.getUniqueID();
-    console.log('ACTIONISSA')
-    return api.deleteBuddyProfile(uuid)
-      .then(response => {
-        dispatch({ type: DELETE_BUDDY_PROFILE_SUCCESS});
-      })
-      .catch(error => {
-        dispatch({ type: DELETE_BUDDY_PROFILE_FAILURE, error: error });
-      });
-  };
-};
-
 const updateProfilePic = (profilePic) => {
   return {type: UPDATE_PROFILE_PIC, payload: profilePic};
 }
@@ -182,6 +166,22 @@ const closeBuddyIntroView = () => {
 
 const closeBuddyRegistrationView = () => {
   return { type: CLOSE_BUDDY_REGISTRATION_VIEW };
+};
+
+const deleteBuddyProfile = () => {
+  return dispatch => {
+    dispatch({ type: DELETE_BUDDY_PROFILE_REQUEST });
+    const uuid = DeviceInfo.getUniqueID();
+    console.log('ACTIONISSA')
+    return api.deleteBuddyProfile(uuid)
+      .then(response => {
+        dispatch({ type: DELETE_BUDDY_PROFILE_SUCCESS });
+        dispatch({ type: UPDATE_BUDDY_REGISTRATION, payload: false });
+      })
+      .catch(error => {
+        dispatch({ type: DELETE_BUDDY_PROFILE_FAILURE, error: error });
+      });
+  };
 };
 
 // Used for getting the user's own profile and keeping it in store
@@ -222,15 +222,13 @@ const putBuddyProfile = (onPutError) => {
     const uuid = DeviceInfo.getUniqueID();
     const bio_text = getStore().registration.get('bio_text');
     const bio_looking_for_type_id = getStore().registration.get('bio_looking_for_type_id');
-    // TODO: Replace this one with the commented-out ones below - after
-    //       the push token is properly generated somewhere in the client
-    const push_token = "INVALID";
-    //const push_token = getStore().registration.get('push_token');
+    const push_token = getStore().registration.get('push_token');
     const class_year = getStore().registration.get('class_year');
     return api.putBuddyProfile({ uuid, bio_text, bio_looking_for_type_id, push_token, class_year })
       .then(response => {
         dispatch({ type: CREATE_USER_SUCCESS });
         dispatch({ type: CLOSE_BUDDY_REGISTRATION_VIEW });
+        dispatch({ type: UPDATE_BUDDY_REGISTRATION, payload: true });
         dispatch({ type: SET_DATA_UPDATED });
       })
       .catch(error => {
@@ -264,6 +262,10 @@ const updateBuddyPushToken = buddyPushToken => {
   return { type: UPDATE_BUDDY_PUSH_TOKEN, payload: buddyPushToken };
 };
 
+const updateBuddyRegistration = buddyRegistration => {
+  return { type: UPDATE_BUDDY_REGISTRATION, payload: buddyRegistration };
+};
+
 // WhappuBuddy registration and profile editing actions end
 
 export {
@@ -283,6 +285,9 @@ export {
   ACKNOWLEDGE_DATA_UPDATE,
   CLOSE_BUDDY_INTRO_VIEW,
   CLOSE_BUDDY_REGISTRATION_VIEW,
+  DELETE_BUDDY_PROFILE_REQUEST,
+  DELETE_BUDDY_PROFILE_SUCCESS,
+  DELETE_BUDDY_PROFILE_FAILURE,
   GET_BUDDY_USER_REQUEST,
   GET_BUDDY_USER_SUCCESS,
   GET_BUDDY_USER_FAILURE,
@@ -298,9 +303,7 @@ export {
   UPDATE_BUDDY_CLASS_YEAR,
   UPDATE_BUDDY_LOOKING_FOR,
   UPDATE_BUDDY_PUSH_TOKEN,
-  DELETE_BUDDY_PROFILE_REQUEST,
-  DELETE_BUDDY_PROFILE_SUCCESS,
-  DELETE_BUDDY_PROFILE_FAILURE,
+  UPDATE_BUDDY_REGISTRATION,
   putUser,
   updateProfilePic,
   putProfilePic,
@@ -316,6 +319,7 @@ export {
   broadcastDataUpdate,
   closeBuddyIntroView,
   closeBuddyRegistrationView,
+  deleteBuddyProfile,
   getBuddyUser,
   getLookingForTypes,
   openBuddyIntroView,
@@ -327,5 +331,5 @@ export {
   updateBuddyClassYear,
   updateBuddyLookingFor,
   updateBuddyPushToken,
-  deleteBuddyProfile
+  updateBuddyRegistration
 };

--- a/app/components/user/UserView.js
+++ b/app/components/user/UserView.js
@@ -36,7 +36,7 @@ import AppInfo from './AppInfo';
 import LegalStuff from './LegalStuff';
 import PopupMenu from './PopupMenu';
 
-import { openRegistrationView, acknowledgeDataUpdate } from '../../actions/registration';
+import { openRegistrationView, acknowledgeDataUpdate, showOtherBuddyProfile } from '../../actions/registration';
 import { getCurrentCityName } from '../../concepts/city';
 import WebViewer from '../webview/WebViewer';
 import BuddyUserView from '../whappubuddy/BuddyUserView';
@@ -107,6 +107,10 @@ class UserView extends Component {
   @autobind
   showBuddyProfile() {
     let { user } = this.props.route;
+
+    // Make sure that BuddyUserView is updated properly if coming from the My Profile mode
+    // of WhappuBuddy
+    this.props.showOtherBuddyProfile();
 
     return () => {
       this.props.navigator.push({
@@ -589,7 +593,8 @@ const mapDispatchToProps = {
   fetchUserImages,
   fetchUserProfile,
   openLightBox,
-  openRegistrationView
+  openRegistrationView,
+  showOtherBuddyProfile
 };
 
 const mapStateToProps = state => ({

--- a/app/components/whappubuddy/BuddyIntroView.js
+++ b/app/components/whappubuddy/BuddyIntroView.js
@@ -144,7 +144,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     textAlign: 'justify',
     color: theme.light,
-    marginBottom: 5,
+    marginBottom: 0,
   },
   imagesContainer: {
     flex: 1,
@@ -157,7 +157,7 @@ const styles = StyleSheet.create({
   innerContainer: {
     flex:1,
     paddingTop:15,
-    paddingBottom: 10,
+    paddingBottom: 5,
     margin: 0,
     borderRadius: 5
   },

--- a/app/components/whappubuddy/BuddyRegistrationView.js
+++ b/app/components/whappubuddy/BuddyRegistrationView.js
@@ -40,6 +40,9 @@ const IOS = Platform.OS === 'ios';
 class BuddyRegistrationView extends Component {
   @autobind
   saveProfile() {
+    if (!this.props.buddyLookingFor) {
+      this.props.updateBuddyLookingFor(1);
+    }
     this.props.putBuddyProfile(this.onSaveError);
   }
 

--- a/app/components/whappubuddy/BuddyUserView.js
+++ b/app/components/whappubuddy/BuddyUserView.js
@@ -114,6 +114,7 @@ class BuddyUserView extends Component {
 
     if (this.props.isDataUpdated && this.props.isOwnBuddyProfileShown) {
       this.props.acknowledgeDataUpdate();
+      this.props.fetchUserProfile(userId);
       this.props.fetchBuddyProfile(userId);
 
     // Ensure that Discover mode is re-entered after changing tabs

--- a/app/components/whappubuddy/DeleteProfileView.js
+++ b/app/components/whappubuddy/DeleteProfileView.js
@@ -1,3 +1,4 @@
+// TODO: Remove unnecessary imports
 
 'use strict';
 
@@ -14,8 +15,6 @@ import theme from '../../style/theme';
 
 const { height, width } = Dimensions.get('window');
 const isIOS = Platform.OS === 'ios';
-
-//let headerImage = require('../../../assets/frontpage_header-bg.jpg');
 
 class DeleteProfileView extends Component {
 
@@ -45,13 +44,13 @@ class DeleteProfileView extends Component {
   render() {
 
     return (
-        <View style={{ flex: 1 }}>
+        <View style={styles.container}>
             <View style={styles.mainView}>
-              <Text style={styles.redText}>Are you sure you want to delete your profile on WhappuBuddy?</Text>
-              <Text style={styles.grayText}>If you delete your profile, other users wont be able to discover you on
+              <Text style={styles.headingText}>Are you sure you want to delete your profile on WhappuBuddy?</Text>
+              <Text style={styles.mainText}>If you delete your profile, other users wont be able to discover you on
                 WhappuBuddy anymore.</Text>
-              <Text style={styles.grayText}>All of your previous matches and chats will also be removed and cannot be recovered.
-                You can, however, rejoin WhappuBuddy later on and start from blank slate.</Text>
+              <Text style={styles.mainText}>All of your previous matches and chats will also be removed and cannot be recovered.
+                You can, however, rejoin WhappuBuddy later on and start from a blank slate.</Text>
               <Text style={styles.boldText}>Please note that leaving WhappuBuddy does not remove your Whappu App profile!</Text>
               <View style={styles.deleteButton}>
                 <Button onPress={this.onDelete}>DELETE MY WHAPPUBUDDY PROFILE</Button>
@@ -63,27 +62,33 @@ class DeleteProfileView extends Component {
 }
 
 const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.danger
+  },
   mainView: {
     flex: 1,
-    marginTop: 40
+    marginTop: 20,
+    padding: 20
   },
-  redText: {
+  headingText: {
     fontWeight: 'bold',
-    fontSize: 20,
-    color: 'red',
-    textAlign: 'center'
+    fontSize: 22,
+    color: theme.accent,
+    textAlign: 'center',
+    marginBottom: 15
   },
-  grayText: {
-    color: 'gray',
+  mainText: {
+    color: theme.accentLight,
     fontSize: 20,
     paddingTop: 20,
     textAlign: 'center'
   },
   boldText: {
-    color: 'gray',
+    color: theme.accentLight,
     fontWeight: 'bold',
     fontSize: 20,
-    paddingTop: 20,
+    paddingTop: 35,
     textAlign: 'center'
   },
   deleteButton: {

--- a/app/containers/BuddyView.js
+++ b/app/containers/BuddyView.js
@@ -50,15 +50,15 @@ class BuddyView extends Component {
 
     switch (tabIndex) {
     case 0:
-      // TODO: Insert MatchesView stuff if needed
+      this.props.showOwnBuddyProfile();
+      this.props.broadcastDataUpdate();
       break;
     case 1:
       this.props.showOtherBuddyProfile();
       this.props.broadcastDataUpdate();
       break;
     case 2:
-      this.props.showOwnBuddyProfile();
-      this.props.broadcastDataUpdate();
+      // TODO: Insert MatchesView stuff if needed
       break;
     default:
     }

--- a/app/containers/FeedView.js
+++ b/app/containers/FeedView.js
@@ -4,8 +4,6 @@ import React, { Component } from 'react';
 import { Navigator, View, StyleSheet, Platform } from 'react-native';
 import autobind from 'autobind-decorator';
 
-import FCM from 'react-native-fcm';
-
 import analytics from '../services/analytics';
 import FeedList from '../components/feed/FeedList';
 import RadioPlayer from '../containers/RadioPlayer'
@@ -31,25 +29,7 @@ const styles = StyleSheet.create({
 
 class FeedView extends Component {
   componentDidMount() {
-
-    console.log('HeilaView :: MOUNTED');
     analytics.viewOpened(VIEW_NAME);
-
-    // FCM.requestPermissions(); // for iOS
-    // TODO: add iOS specific hanlding here
-
-    FCM.getFCMToken().then(token => {
-      console.log('FCM.getFCMToken --> token ::: ')
-      console.log(token)
-      // client should now send this token to the server
-    });
-
-    this.refreshTokenListener = FCM.on('refreshToken', (token) => {
-      console.log('refreshTokenListener ----->> token ::')
-      console.log(token)
-      // fcm token may not be available on first load, catch it here
-    });
-
   }
 
   @autobind

--- a/app/reducers/registration.js
+++ b/app/reducers/registration.js
@@ -34,6 +34,7 @@ import {
   UPDATE_BUDDY_CLASS_YEAR,
   UPDATE_BUDDY_LOOKING_FOR,
   UPDATE_BUDDY_PUSH_TOKEN,
+  UPDATE_BUDDY_REGISTRATION,
   DELETE_BUDDY_PROFILE_SUCCESS,
   DELETE_BUDDY_PROFILE_REQUEST,
   DELETE_BUDDY_PROFILE_FAILURE,
@@ -160,6 +161,8 @@ export default function registration(state = initialState, action) {
       return state.set('bio_looking_for_type_id', action.payload);
     case UPDATE_BUDDY_PUSH_TOKEN:
       return state.set('push_token', action.payload);
+    case UPDATE_BUDDY_REGISTRATION:
+      return state.set('heila', action.payload);
     case DELETE_BUDDY_PROFILE_SUCCESS:
     return state.set('isOnWhappuBuddy', false);
     case DELETE_BUDDY_PROFILE_REQUEST:


### PR DESCRIPTION
- Fixed BuddyUserView not updating to reflect changes upon registering a WhappuBuddy profile while in My Profile mode.
- Fixed push notifications not working in the foreground.
- Fixed push notifications not transfering the user to WhappuBuddy.
- Fixed BuddyView tab changing functionality to properly place My Profile on the left side.
- Fixed BuddyUserView not retrieving the user's guild properly upon registering to WhappuBuddy.
- Fixed BuddyUserView showing the wrong profile if accessed through a Whappu Log right after leaving the My Profile section in WhappuBuddy.
- Fixed Looking For not being set properly if the user went with the default choice in BuddyRegistrationView.
- Fixed the Firebase push notification token not getting sent to the backend upon saving WhappuBuddy profile data.
- Changed DeleteProfileView styles to appear more alerting to the user to avoid accidental WhappuBuddy profile deletions.
- Changed BuddyIntroView styles to make the view a bit smaller to avoid scrolling on modern devices.

Known issues:
- The UserAvatar profile picture in RegistrationView is not updated after changing it, saving the changes and accessing RegistrationView again.
- If the user hasn't registered on WhappuBuddy, fetchUserBuddies returns an empty list and potential buddies cannot be browsed. This might be a backend problem.
- The opinion and skip buttons in BuddyUserView don't have shadows on Android because Image cannot have the style property 'elevation'.
- Part of the ParallaxView header (containing the user's name, guild and class year) is not rendered at times. This is currently somehow fixed (in a dirty and ugly way) by having added invisible View and Text elements above it.